### PR TITLE
Fix check in ZoomableImageView 

### DIFF
--- a/krop/src/main/java/com/avito/android/krop/ZoomableImageView.kt
+++ b/krop/src/main/java/com/avito/android/krop/ZoomableImageView.kt
@@ -411,14 +411,12 @@ class ZoomableImageView : ImageView {
         val redundantYSpace = viewSize.height - scaleY * drawableHeight
         matchViewSize.width = viewSize.width - redundantXSpace
         matchViewSize.height = viewSize.height - redundantYSpace
-        if (!isZoomed && !imageRenderedAtLeastOnce) {
+
+        if ((!isZoomed && !imageRenderedAtLeastOnce) || (prevMatchViewSize.width == 0.0f && prevMatchViewSize.height == 0.0f)) {
             imgMatrix.setScale(scaleX, scaleY)
             imgMatrix.postTranslate(redundantXSpace / 2, redundantYSpace / 2)
             currentZoom = 1.0f
         } else {
-            if (prevMatchViewSize.width == 0.0f || prevMatchViewSize.height == 0.0f) {
-                savePreviousImageValues()
-            }
 
             prevMatrix.getValues(matrix)
 


### PR DESCRIPTION
Fix for issue https://github.com/avito-tech/krop/issues/6
Rework checking logic, now it correctly work with cases when prevMatchViewSize store 0 values.