### PR TITLE
Fixed issue with opaque overlay making image completely black.

### DIFF
--- a/krop/src/main/java/com/avito/android/krop/KropView.kt
+++ b/krop/src/main/java/com/avito/android/krop/KropView.kt
@@ -56,7 +56,7 @@ class KropView(context: Context, attrs: AttributeSet) : FrameLayout(context, att
         addView(imageView)
 
         overlayView = OverlayView(context)
-        overlayView.setBackgroundColor(overlayColor)
+        overlayView.setOverlayColor(overlayColor)
         addView(overlayView)
     }
 
@@ -134,7 +134,7 @@ class KropView(context: Context, attrs: AttributeSet) : FrameLayout(context, att
 
     fun applyOverlayColor(color: Int) {
         this.overlayColor = color
-        overlayView.setBackgroundColor(overlayColor)
+        overlayView.setOverlayColor(overlayColor)
         invalidate()
     }
 
@@ -163,7 +163,7 @@ class KropView(context: Context, attrs: AttributeSet) : FrameLayout(context, att
             aspectY = state.aspectY
             overlayColor = state.overlayColor
             imageView.onRestoreInstanceState(state.imageViewState)
-            overlayView.setBackgroundColor(overlayColor)
+            overlayView.setOverlayColor(overlayColor)
         } else {
             super.onRestoreInstanceState(state)
         }

--- a/krop/src/main/java/com/avito/android/krop/OverlayView.kt
+++ b/krop/src/main/java/com/avito/android/krop/OverlayView.kt
@@ -11,15 +11,17 @@ import android.view.View
 
 class OverlayView(context: Context) : View(context) {
 
-    private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private var overlayColor: Int = Color.TRANSPARENT
+    private val clearPaint = Paint(Paint.ANTI_ALIAS_FLAG)
 
     var viewport = RectF()
 
     init {
         setLayerType(View.LAYER_TYPE_SOFTWARE, null)
-        paint.color = Color.BLACK
-        paint.style = Paint.Style.FILL
-        paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
+
+        clearPaint.color = Color.BLACK
+        clearPaint.style = Paint.Style.FILL
+        clearPaint.xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
@@ -38,10 +40,16 @@ class OverlayView(context: Context) : View(context) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
     }
 
+    fun setOverlayColor(color: Int) {
+        overlayColor = color
+        invalidate()
+    }
+
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
-        canvas.drawOval(viewport, paint)
+        canvas.drawColor(overlayColor)
+        canvas.drawOval(viewport, clearPaint)
     }
 
 }


### PR DESCRIPTION
Instead of using `setBackgroundColor()` just draw overlay color manually.

This PR fixes issue #10.