### PR TITLE
Fixed of factor calculation in Transformation.forSize()

### DIFF
--- a/krop/src/main/java/com/avito/android/krop/Transformation.kt
+++ b/krop/src/main/java/com/avito/android/krop/Transformation.kt
@@ -11,7 +11,7 @@ class Transformation(var size: SizeF = SizeF(), var crop: RectF = RectF()) : Par
         get() = crop.isEmpty
 
     fun forSize(size: SizeF): RectF {
-        val factor = this.size.width / size.width
+        val factor = size.width / this.size.width
         return RectF(
                 crop.left * factor,
                 crop.top * factor,


### PR DESCRIPTION
Function forSize() works incorrectly because of factor.